### PR TITLE
GamePadHelper: fix API-misuse bugs and shrink console map cache

### DIFF
--- a/GamePadHelper/GamePadHelper.lua
+++ b/GamePadHelper/GamePadHelper.lua
@@ -55,7 +55,6 @@ local defaults = {
     tooltipFontEnabled = true,
     tooltipEnchantmentEnabled = true,
     lastAnnouncedVersion = 0,
-    overviewDebug = {},
 }
 _G["GamePadHelper_Defaults"] = defaults
 

--- a/GamePadHelper/modules/AutoCharge.lua
+++ b/GamePadHelper/modules/AutoCharge.lua
@@ -13,24 +13,22 @@ local function GetSlotName(equipSlot)
 end
 
 local function FindSoulGem()
-    -- Find the best soul gem in inventory
-    local bestGem = nil
+    -- Find the best (highest-tier) filled soul gem in the backpack.
+    local bestTier = nil
     local bestBagId, bestSlotIndex = nil, nil
 
     local bagId = BAG_BACKPACK
     for slotIndex = 0, GetBagSize(bagId) - 1 do
         local itemLink = GetItemLink(bagId, slotIndex)
-        if itemLink and itemLink ~= "" then
-            local itemType = GetItemLinkItemType(itemLink)
-            if itemType == ITEMTYPE_SOUL_GEM then
-                local soulGemType, gemLevel, isFilledSoulGem = GetSoulGemInfo(bagId, slotIndex)
-                if isFilledSoulGem then
-                    if not bestGem or gemLevel > bestGem then
-                        bestGem = gemLevel
-                        bestBagId = bagId
-                        bestSlotIndex = slotIndex
-                    end
-                end
+        if itemLink and itemLink ~= "" and GetItemLinkItemType(itemLink) == ITEMTYPE_SOUL_GEM then
+            -- GetSoulGemItemInfo takes (bagId, slotIndex) and returns (tier, soulGemType).
+            -- (The old GetSoulGemInfo call is type/level-based and returned name/icon/count,
+            -- so the filled check and "best level" comparison never worked.)
+            local tier, soulGemType = GetSoulGemItemInfo(bagId, slotIndex)
+            if soulGemType == SOUL_GEM_TYPE_FILLED and (not bestTier or tier > bestTier) then
+                bestTier = tier
+                bestBagId = bagId
+                bestSlotIndex = slotIndex
             end
         end
     end

--- a/GamePadHelper/modules/AutoEye.lua
+++ b/GamePadHelper/modules/AutoEye.lua
@@ -47,6 +47,8 @@ end
 
 local function MainLoop()
     if not _G["GamePadHelper_SavedVars"] or not _G["GamePadHelper_SavedVars"].antiquariansEyeEnabled then
+        -- If we swapped the Eye in earlier, restore the player's quickslot when disabled.
+        if eyeIsActive then UnslotEye() end
         return
     end
     if not IsCollectibleBlocked(ANTIQUARIANS_EYE_ID) then

--- a/GamePadHelper/modules/Fishing.lua
+++ b/GamePadHelper/modules/Fishing.lua
@@ -50,10 +50,25 @@ AddFishingHoleName("River Fishing Hole",     RIVER_HOLE)
 
 local setBait = true
 
+local function CountItemInBag(bagId, itemId)
+    local total = 0
+    for slotIndex = 0, GetBagSize(bagId) - 1 do
+        if GetItemId(bagId, slotIndex) == itemId then
+            total = total + GetSlotStackSize(bagId, slotIndex)
+        end
+    end
+    return total
+end
+
+-- GetItemInfo takes a slot index, not an item id, so the old lookup read the
+-- wrong slots and never returned a real bait count. Count matching stacks in the
+-- backpack (and the craft bag when accessible) instead.
 local function GetItemQuantity(itemId)
-    local _, qnt  = GetItemInfo(BAG_VIRTUAL, itemId)
-    local _, qnt2 = GetItemInfo(BAG_BACKPACK, itemId)
-    if HasCraftBagAccess() then return (qnt + qnt2) else return qnt2 end
+    local total = CountItemInBag(BAG_BACKPACK, itemId)
+    if HasCraftBagAccess() then
+        total = total + CountItemInBag(BAG_VIRTUAL, itemId)
+    end
+    return total
 end
 
 local function SelectFishingBait(interactableName)

--- a/GamePadHelper/modules/MapSearch.lua
+++ b/GamePadHelper/modules/MapSearch.lua
@@ -96,7 +96,8 @@ local zoneQuestCounts = nil
 
 local cityServicesCache = nil  -- { locations=[], tradersByNodeIndex={} }, populated on first use
 local traderGuildMap    = nil  -- trader/guild tooltip data, built with city cache
-local CITY_SCAN_CACHE_VERSION = 14
+local CITY_SCAN_CACHE_VERSION = 15  -- bumped: on-disk cache is now compacted (interned icons, no aliases, rounded coords)
+local CITY_SCAN_BATCH = 12          -- maps scanned per frame during the background (chunked) pre-warm
 local clickableSubMapCache = nil
 local craftingPOIIndex = {}  -- "zoneId:pxKey:pyKey" -> poiIndex, built during PreScan
 
@@ -959,12 +960,20 @@ local function ScanCurrentMapLocations(scan)
     return traderCount
 end
 
-local function ScanCityServices()
+local function ScanCityServices(yielder)
     local originalMapId = GetCurrentMapId and GetCurrentMapId() or nil
     local locations = {}
     local tradersByNodeIndex = {}
     local seenCityMapIds = {}
     local seenLocations = {}
+
+    -- When a yielder is supplied (background pre-warm) the whole-game scan runs in
+    -- small batches, handing control back between frames so it never blows the console
+    -- per-frame execution budget. The map is restored to where it was at the start of
+    -- each batch before yielding, so an open world map never visibly jumps. With no
+    -- yielder this runs straight through exactly like before (synchronous fallback).
+    local batchStartMap = originalMapId
+    local sinceYield = 0
 
     for mapIndex = 1, GetNumMaps() do
         local mapName, mapType, _, zoneIndex = GetMapInfoByIndex(mapIndex)
@@ -1012,6 +1021,16 @@ local function ScanCityServices()
                 end
             end
         end
+
+        if yielder then
+            sinceYield = sinceYield + 1
+            if sinceYield >= CITY_SCAN_BATCH then
+                sinceYield = 0
+                if batchStartMap then SetMapToMapId(batchStartMap) end
+                yielder()
+                batchStartMap = GetCurrentMapId and GetCurrentMapId() or nil
+            end
+        end
     end
 
     for _, subMap in ipairs(GetClickableSubMaps()) do
@@ -1035,11 +1054,92 @@ local function ScanCityServices()
         end
     end
 
-    if originalMapId then SetMapToMapId(originalMapId) end
+    -- Restore the map to where it was at the start of the final batch (= scan start
+    -- for the synchronous path, since batchStartMap is never advanced without a yielder).
+    if batchStartMap then SetMapToMapId(batchStartMap) end
     return {
         locations = locations,
         tradersByNodeIndex = tradersByNodeIndex,
         version = CITY_SCAN_CACHE_VERSION,
+    }
+end
+
+-- --- Saved-cache compaction -------------------------------------------------
+-- The in-memory city cache stays "rich" (every consumer reads it unchanged). Only
+-- the on-disk copy is shrunk to keep the console autosave small: icon paths are
+-- interned into a shared list, the redundant `aliases` string is dropped (it is
+-- rebuilt from npcLines + category on load), and float coords are rounded.
+
+local function RoundCoord(v)
+    if type(v) ~= "number" then return v end
+    return math.floor(v * 10000 + 0.5) / 10000
+end
+
+local function BuildAliasesFromLines(name, category, npcLines)
+    local parts = {}
+    name = name or ""
+    if npcLines then
+        for _, line in ipairs(npcLines) do
+            if line and line ~= "" and line ~= name then parts[#parts + 1] = line end
+        end
+    end
+    if category and category ~= "" and category ~= name then parts[#parts + 1] = category end
+    return table.concat(parts, " ")
+end
+
+local function CompactCityScanForSave(cache)
+    if not cache or not cache.locations then return cache end
+
+    local iconList, iconIndex = {}, {}
+    local function internIcon(icon)
+        icon = icon or ""
+        local idx = iconIndex[icon]
+        if not idx then
+            iconList[#iconList + 1] = icon
+            idx = #iconList
+            iconIndex[icon] = idx
+        end
+        return idx
+    end
+
+    local outLocations = {}
+    for i = 1, #cache.locations do
+        local loc = cache.locations[i]
+        local copy = {}
+        for k, v in pairs(loc) do copy[k] = v end
+        copy.aliases = nil                          -- rebuilt on load
+        copy.icon = internIcon(loc.icon)            -- index into iconList
+        copy.destinationX = RoundCoord(loc.destinationX)
+        copy.destinationY = RoundCoord(loc.destinationY)
+        outLocations[i] = copy
+    end
+
+    return {
+        version = cache.version or CITY_SCAN_CACHE_VERSION,
+        locations = outLocations,
+        tradersByNodeIndex = cache.tradersByNodeIndex,
+        icons = iconList,
+    }
+end
+
+local function RehydrateCityScan(saved)
+    if not saved or not saved.locations then return nil end
+    local iconList = saved.icons or {}
+    local outLocations = {}
+    for i = 1, #saved.locations do
+        local loc = saved.locations[i]
+        local copy = {}
+        for k, v in pairs(loc) do copy[k] = v end
+        if type(copy.icon) == "number" then
+            copy.icon = iconList[copy.icon] or ""
+        end
+        copy.aliases = BuildAliasesFromLines(copy.name, copy.category, copy.npcLines)
+        outLocations[i] = copy
+    end
+    return {
+        version = saved.version or CITY_SCAN_CACHE_VERSION,
+        locations = outLocations,
+        tradersByNodeIndex = saved.tradersByNodeIndex,
     }
 end
 
@@ -1049,7 +1149,7 @@ local function LoadCityScanFromSavedVars()
         and mapData.cityScanCache.version == CITY_SCAN_CACHE_VERSION
         and mapData.cityScanCache.locations
         and mapData.cityScanCache.tradersByNodeIndex then
-        cityServicesCache = mapData.cityScanCache
+        cityServicesCache = RehydrateCityScan(mapData.cityScanCache)
     end
 end
 
@@ -1130,7 +1230,7 @@ local function GetCityServices()
         or not cityServicesCache.tradersByNodeIndex then
         cityServicesCache = ScanCityServices()
         if not _G["GamePadHelperMapData"] then _G["GamePadHelperMapData"] = {} end
-        _G["GamePadHelperMapData"].cityScanCache = cityServicesCache
+        _G["GamePadHelperMapData"].cityScanCache = CompactCityScanForSave(cityServicesCache)
     end
     if not traderGuildMap then
         traderGuildMap = BuildTraderOwnershipLookup()
@@ -1141,6 +1241,59 @@ end
 local function GetTraderOwnershipLookup()
     if not traderGuildMap then GetCityServices() end
     return traderGuildMap
+end
+
+local SCAN_PREWARM_UPDATE = "GamePadHelper_CityScanPrewarm"
+local cityScanPrewarmActive = false
+
+local function IsCityCacheReady()
+    return cityServicesCache
+        and cityServicesCache.version == CITY_SCAN_CACHE_VERSION
+        and cityServicesCache.locations
+        and cityServicesCache.tradersByNodeIndex
+end
+
+-- Build the city-services cache in the background, a few maps per frame, instead of
+-- one big synchronous scan. GetCityServices() still has the synchronous scan as a
+-- fallback, so a search that arrives before this finishes is never blocked.
+local function StartCityScanPrewarm(onComplete)
+    if cityScanPrewarmActive then return end
+    if IsCityCacheReady() then
+        if onComplete then onComplete() end
+        return
+    end
+
+    cityScanPrewarmActive = true
+    local co = coroutine.create(function()
+        return ScanCityServices(coroutine.yield)
+    end)
+
+    EVENT_MANAGER:RegisterForUpdate(SCAN_PREWARM_UPDATE, 0, function()
+        -- Something else (e.g. a search forcing a synchronous scan) finished first.
+        if IsCityCacheReady() then
+            EVENT_MANAGER:UnregisterForUpdate(SCAN_PREWARM_UPDATE)
+            cityScanPrewarmActive = false
+            return
+        end
+
+        local ok, result = coroutine.resume(co)
+        if not ok then
+            -- Scan errored: stop quietly; a later search falls back to a sync scan.
+            EVENT_MANAGER:UnregisterForUpdate(SCAN_PREWARM_UPDATE)
+            cityScanPrewarmActive = false
+            return
+        end
+
+        if coroutine.status(co) == "dead" then
+            EVENT_MANAGER:UnregisterForUpdate(SCAN_PREWARM_UPDATE)
+            cityScanPrewarmActive = false
+            cityServicesCache = result
+            if not _G["GamePadHelperMapData"] then _G["GamePadHelperMapData"] = {} end
+            _G["GamePadHelperMapData"].cityScanCache = CompactCityScanForSave(result)
+            traderGuildMap = BuildTraderOwnershipLookup()
+            if onComplete then onComplete() end
+        end
+    end)
 end
 
 local function GetOwnedGuildNamesForCandidate(c)
@@ -2740,9 +2893,19 @@ local function OnAddonLoaded(_, name)
         EVENT_MANAGER:UnregisterForEvent("MapSearch_PreScan", EVENT_PLAYER_ACTIVATED)
         if not scannedData then PreScan() end
         LoadCityScanFromSavedVars()
-        zo_callLater(function()
-            if not candidates then candidates = BuildCandidates() end
-        end, 3000)
+        if cityServicesCache then
+            -- Valid cache loaded from disk; just build the candidate list shortly.
+            zo_callLater(function()
+                if not candidates then candidates = BuildCandidates() end
+            end, 3000)
+        else
+            -- No saved cache (fresh account or version bump): build it in the
+            -- background (chunked) to stay under the console per-frame budget,
+            -- then build candidates from the ready cache.
+            StartCityScanPrewarm(function()
+                candidates = BuildCandidates()
+            end)
+        end
     end)
 
     EVENT_MANAGER:RegisterForEvent("MapSearch_RecallNodeReset", EVENT_PLAYER_ACTIVATED, function()
@@ -3008,7 +3171,10 @@ _G["GamePadHelper_ClearCityCache"] = function()
     local mapData = _G["GamePadHelperMapData"]
     if mapData then mapData.cityScanCache = nil end
     zo_callLater(function()
-        if not candidates then candidates = BuildCandidates() end
+        -- Rebuild the cache in the background, then refresh the candidate list.
+        StartCityScanPrewarm(function()
+            candidates = BuildCandidates()
+        end)
     end, 500)
 end
 

--- a/GamePadHelper/modules/Provisioning.lua
+++ b/GamePadHelper/modules/Provisioning.lua
@@ -25,37 +25,36 @@ local function HideRecipes(recipeList)
         end
     end
 
-    -- Pass 2: remove entries in reverse to preserve indices
-    for i = recipeList:GetNumEntries(), 1, -1 do
-        if toRemove[i] then
-            local template = recipeList.templateList[i]
-            local recipeData = recipeList.dataList[i]
-            recipeList:RemoveEntry(template, recipeData)
+    local n = recipeList:GetNumEntries()
+
+    -- Pass 2: preserve category headings. The game attaches each group's header to
+    -- that group's first entry (data.header set, *WithHeader template). If that entry
+    -- is being removed, hand its header to the first surviving member of the SAME group
+    -- so the heading isn't lost. A forward pass with a "pending" header keeps the right
+    -- heading even when several whole groups are removed back-to-back.
+    -- (Identifying headers by data.header rather than a template-name literal is what
+    -- makes this work — the real template is "ZO_Provisioner_..." not the generic name.)
+    local pendingHeader, pendingTemplate = nil, nil
+    for i = 1, n do
+        local data = recipeList.dataList[i]
+        if data and data.header then
+            if toRemove[i] then
+                pendingHeader = data.header
+                pendingTemplate = recipeList.templateList[i]
+            else
+                pendingHeader, pendingTemplate = nil, nil
+            end
+        elseif data and not toRemove[i] and pendingHeader then
+            data.header = pendingHeader
+            recipeList.templateList[i] = pendingTemplate
+            pendingHeader, pendingTemplate = nil, nil
         end
     end
 
-    -- Pass 3: remove orphaned headers (header with no visible entries before next header or end of list)
-    local i = 1
-    while i <= recipeList:GetNumEntries() do
-        local template = recipeList.templateList[i]
-        if template == "ZO_GamepadItemSubEntryTemplateWithHeader" then
-            if i == recipeList:GetNumEntries() then
-                -- Last entry is a header with no following content
-                local recipeData = recipeList.dataList[i]
-                recipeList:RemoveEntry(template, recipeData)
-            else
-                local nextData = recipeList.dataList[i + 1]
-                local nextTemplate = recipeList.templateList[i + 1]
-                -- Check if next entry is also a header → this one has no visible content
-                if nextData and nextData.header and nextTemplate == "ZO_GamepadItemSubEntryTemplateWithHeader" then
-                    local recipeData = recipeList.dataList[i]
-                    recipeList:RemoveEntry(template, recipeData)
-                else
-                    i = i + 1
-                end
-            end
-        else
-            i = i + 1
+    -- Pass 3: remove marked entries in reverse so earlier indices stay valid
+    for i = n, 1, -1 do
+        if toRemove[i] then
+            recipeList:RemoveEntry(recipeList.templateList[i], recipeList.dataList[i])
         end
     end
 

--- a/GamePadHelper/modules/TooltipEnchantment.lua
+++ b/GamePadHelper/modules/TooltipEnchantment.lua
@@ -10,7 +10,6 @@ local function Tooltip_AddEnchant_Before(self, itemLink, enchantDiffMode, equipS
 
     if hasEnchant and LibItemLinkDecoder then
         local decodedItemLink = LibItemLinkDecoder:Decode(itemLink)
-        local quality = decodedItemLink.enchantQuality
         local qualityColor = GetItemQualityColor(decodedItemLink.enchantQuality)
 
         local headerText = qualityColor:Colorize(enchantHeader)
@@ -22,11 +21,6 @@ local function Tooltip_AddEnchant_Before(self, itemLink, enchantDiffMode, equipS
             COLOR_WHITE:Colorize(tostring(decodedItemLink.enchantChampionLevel > 0 and decodedItemLink.enchantChampionLevel or decodedItemLink.enchantLevel))
         )
 
-        local bodyColor =
-            enchantDiffMode == ZO_ENCHANT_DIFF_ADD and GAMEPAD_TOOLTIP_COLOR_ABILITY_UPGRADE or
-            enchantDiffMode == ZO_ENCHANT_DIFF_REMOVE and GAMEPAD_TOOLTIP_COLOR_FAILED or
-            IsItemAffectedByPairedPoison(equipSlot) and GAMEPAD_TOOLTIP_COLOR_INACTIVE or
-            GENERAL_COLOR_OFF_WHITE
         local bodyText = enchantDescription:gsub("\n\n", " "):gsub("\n", " ")
 
         if enchantDiffMode == ZO_ENCHANT_DIFF_NONE and IsItemAffectedByPairedPoison(equipSlot) then


### PR DESCRIPTION
## Summary

Fixes several API-misuse bugs in GamePadHelper modules and reduces the console save-size / per-frame cost of the Map Search city cache (`GamePadHelperMapData`). All changed files pass `luac5.1 -p`.

## Bug fixes

- **AutoCharge:** used `GetSoulGemInfo(bag, slot)` — but that function is type/level-based and returns `name, icon, count`, so the "is filled" check and "best level" comparison never worked (empty gems could be selected; ranking compared icon path strings). Now uses `GetSoulGemItemInfo(bag, slot)` → `tier, soulGemType`, filtering on `SOUL_GEM_TYPE_FILLED` and ranking by `tier`.
- **Fishing:** `GetItemQuantity` called `GetItemInfo(bag, itemId)`, but `GetItemInfo` takes a *slot index*, so the bait count was bogus (and could throw in the reticle hook for craft-bag/ESO+ users). Now counts matching stacks via `GetItemId` / `GetSlotStackSize`.
- **Provisioning:** category headers were lost when the header-carrying recipe of a group was hidden. The header logic compared the generic template name, but the real provisioner template is `ZO_Provisioner_GamepadItemSubEntryTemplateWithHeader`, so it never matched. Replaced with a forward "pending header" pass keyed on `data.header` that moves a removed group head's heading onto the first surviving recipe of the same group.
- **TooltipEnchantment:** removed dead `bodyColor`/`quality` locals.
- **AutoEye:** restore the player's quickslot when the feature is toggled off mid-session.
- Removed the unused `overviewDebug` saved-variable default.

## Console save error / performance (`GamePadHelperMapData`)

- **Compact the on-disk city cache:** intern repeated icon paths into a shared list, drop the redundant `aliases` string (rebuilt from `npcLines` + `category` on load), and round coords. The in-memory cache stays "rich", so no consumers change. Cache version bumped `14 → 15` so existing bloated caches are discarded and rewritten compactly on next login.
- **Chunk the whole-game scan:** `ScanCityServices` is now yield-aware and is driven by a background coroutine pre-warm (a few maps per frame), restoring the current map between batches so an open world map doesn't visibly jump. `GetCityServices` keeps the original synchronous scan as a fallback, so a search arriving before the pre-warm finishes is never blocked (worst case = previous behavior).

## Testing notes

- Provisioning with "show low-level recipes" off — category headers stay correct.
- Map Search first-time use / after "Clear cache" — results populate after the background scan; world map doesn't flicker.
- AutoCharge picks the best filled gem; Fishing alternative-bait selection works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)